### PR TITLE
chore: better error logging with IDs

### DIFF
--- a/src/gmp_api/gmp_types.rs
+++ b/src/gmp_api/gmp_types.rs
@@ -250,6 +250,20 @@ impl Task {
         }
     }
 
+    pub fn message_id(&self) -> Option<String> {
+        match self {
+            Task::Execute(t) => Some(t.task.message.message_id.clone()),
+            Task::Verify(t) => Some(t.task.message.message_id.clone()),
+            Task::ConstructProof(t) => Some(t.task.message.message_id.clone()),
+            Task::Refund(t) => Some(t.task.message.message_id.clone()),
+            Task::GatewayTx(_)
+            | Task::ReactToWasmEvent(_)
+            | Task::ReactToExpiredSigningSession(_)
+            | Task::ReactToRetriablePoll(_)
+            | Task::Unknown(_) => None,
+        }
+    }
+
     pub fn kind(&self) -> TaskKind {
         use Task::*;
         match self {

--- a/src/gmp_api/gmp_types.rs
+++ b/src/gmp_api/gmp_types.rs
@@ -250,20 +250,6 @@ impl Task {
         }
     }
 
-    pub fn message_id(&self) -> Option<String> {
-        match self {
-            Task::Execute(t) => Some(t.task.message.message_id.clone()),
-            Task::Verify(t) => Some(t.task.message.message_id.clone()),
-            Task::ConstructProof(t) => Some(t.task.message.message_id.clone()),
-            Task::Refund(t) => Some(t.task.message.message_id.clone()),
-            Task::GatewayTx(_)
-            | Task::ReactToWasmEvent(_)
-            | Task::ReactToExpiredSigningSession(_)
-            | Task::ReactToRetriablePoll(_)
-            | Task::Unknown(_) => None,
-        }
-    }
-
     pub fn kind(&self) -> TaskKind {
         use Task::*;
         match self {

--- a/src/includer.rs
+++ b/src/includer.rs
@@ -7,6 +7,7 @@ use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, info_span, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
+use crate::gmp_api::utils::extract_message_ids_from_task;
 use crate::gmp_api::GmpApiTrait;
 use crate::includer_worker::{IncluderTrait, IncluderWorker, IncluderWorkerTrait};
 use crate::logging::{distributed_tracing_extract_parent_context, maybe_instrument};
@@ -88,7 +89,11 @@ where
                     _ => {
                         let (task_id, message_id) = match serde_json::from_slice::<QueueItem>(&data)
                         {
-                            Ok(QueueItem::Task(task)) => (Some(task.id()), task.message_id()),
+                            Ok(QueueItem::Task(task)) => {
+                                let msg_id =
+                                    extract_message_ids_from_task(&task).into_iter().next();
+                                (Some(task.id()), msg_id)
+                            }
                             _ => (None, None),
                         };
                         error!(

--- a/src/includer.rs
+++ b/src/includer.rs
@@ -86,7 +86,17 @@ where
                         force_requeue = true;
                     }
                     _ => {
-                        error!("Failed to consume delivery: {:?}", e);
+                        let (task_id, message_id) = match serde_json::from_slice::<QueueItem>(&data)
+                        {
+                            Ok(QueueItem::Task(task)) => (Some(task.id()), task.message_id()),
+                            _ => (None, None),
+                        };
+                        error!(
+                            task_id = task_id.as_deref().unwrap_or("unknown"),
+                            message_id = message_id.as_deref().unwrap_or("n/a"),
+                            "Failed to consume delivery: {:?}",
+                            e
+                        );
                     }
                 }
 

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -1,3 +1,4 @@
+use crate::gmp_api::utils::extract_message_ids_from_task;
 use crate::gmp_api::{GmpApi, GmpApiDbAuditDecorator};
 use crate::ingestor_worker::{IngestorWorker, IngestorWorkerTrait};
 use crate::logging::{distributed_tracing_extract_parent_context, maybe_instrument};
@@ -71,7 +72,11 @@ where
                     _ => {
                         let (task_id, message_id) = match serde_json::from_slice::<QueueItem>(&data)
                         {
-                            Ok(QueueItem::Task(task)) => (Some(task.id()), task.message_id()),
+                            Ok(QueueItem::Task(task)) => {
+                                let msg_id =
+                                    extract_message_ids_from_task(&task).into_iter().next();
+                                (Some(task.id()), msg_id)
+                            }
                             _ => (None, None),
                         };
                         error!(

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -69,7 +69,17 @@ where
                         force_requeue = true;
                     }
                     _ => {
-                        error!("Failed to consume delivery: {:?}", e);
+                        let (task_id, message_id) = match serde_json::from_slice::<QueueItem>(&data)
+                        {
+                            Ok(QueueItem::Task(task)) => (Some(task.id()), task.message_id()),
+                            _ => (None, None),
+                        };
+                        error!(
+                            task_id = task_id.as_deref().unwrap_or("unknown"),
+                            message_id = message_id.as_deref().unwrap_or("n/a"),
+                            "Failed to consume delivery: {:?}",
+                            e
+                        );
                     }
                 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to error logging paths in `ingestor`/`includer`, adding a best-effort JSON parse to attach IDs; functional queue processing behavior is unchanged aside from minor extra work on failures.
> 
> **Overview**
> Improves failure diagnostics in `ingestor` and `includer` by enriching `Failed to consume delivery` logs with structured `task_id` and `message_id` fields.
> 
> On processing errors (non-*IrrelevantTask*), the consumer now attempts to deserialize the delivery as a `QueueItem::Task` and extracts IDs via `extract_message_ids_from_task`, falling back to `unknown`/`n/a` when unavailable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2f48806a9dd27bfc87bc7e20805a48e2824175f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->