### PR TITLE
chore: use network in docker names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ certs
 config.mainnet.yaml
 config.devnet.yaml
 config.testnet.yaml
+config.stagenet.yaml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,6 +92,10 @@ path = "src/bin/recovery/dlq_recovery.rs"
 name = "task_recovery"
 path = "src/bin/recovery/task_recovery.rs"
 
+[[bin]]
+name = "heartbeat_monitor"
+path = "src/bin/heartbeat_monitor.rs"
+
 [features]
 mocks = ["dep:mockall"]
 instrumentation = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,8 @@ RUN mkdir -p src/bin/scripts src/bin/recovery && \
     echo 'fn main() {}' > src/bin/scripts/queue_migration.rs && \
     echo 'fn main() {}' > src/bin/recovery/proof_retrier.rs && \
     echo 'fn main() {}' > src/bin/recovery/task_recovery.rs && \
-    echo 'fn main() {}' > src/bin/recovery/dlq_recovery.rs
+    echo 'fn main() {}' > src/bin/recovery/dlq_recovery.rs && \
+    echo 'fn main() {}' > src/bin/heartbeat_monitor.rs
 
 
 # Build dependencies (this will cache them)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+name: ${NETWORK}-axelar-relayer-core
+
 services:
   distributor:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,14 @@ services:
     env_file:
       - .env
 
+  heartbeat_monitor:
+    build:
+      context: .
+      args:
+        BINARY_NAME: heartbeat_monitor
+    env_file:
+      - .env
+
   redis:
     image: redis:alpine
     container_name: redis
@@ -136,4 +144,4 @@ volumes:
 
 networks:
   axelar-relayer:
-    name: axelar-relayer
+    name: ${NETWORK}-axelar-relayer-core

--- a/src/bin/heartbeat_monitor.rs
+++ b/src/bin/heartbeat_monitor.rs
@@ -1,0 +1,12 @@
+use dotenv::dotenv;
+use relayer_core::config::{config_from_yaml, Config};
+use relayer_core::heartbeat::heartbeats_loop;
+
+#[tokio::main]
+async fn main() -> Result<(), anyhow::Error> {
+    dotenv().ok();
+    let network = std::env::var("NETWORK").expect("NETWORK must be set");
+    let config: Config = config_from_yaml(&format!("config.{}.yaml", network))?;
+
+    heartbeats_loop(&config).await;
+}

--- a/src/bin/recovery/task_recovery.rs
+++ b/src/bin/recovery/task_recovery.rs
@@ -49,6 +49,8 @@ async fn main() -> anyhow::Result<()> {
             tasks_filter: Some(vec![TaskKind::Execute]),
             task_ids_filter: Some(vec!["019a93a4-9038-77fc-ba57-6264b49d9f70".to_string()]),
             // task_ids_filter: None,
+            message_ids_filter: Some(vec!["0x-placeholder-message-id".to_string()]),
+            // message_ids_filter: None,
         },
         config.refunds_enabled,
         Arc::new(logging_ctx_cache),

--- a/src/distributor.rs
+++ b/src/distributor.rs
@@ -18,6 +18,7 @@ pub struct RecoverySettings {
     pub to_task_id: String,
     pub tasks_filter: Option<Vec<TaskKind>>,
     pub task_ids_filter: Option<Vec<String>>,
+    pub message_ids_filter: Option<Vec<String>>,
 }
 
 pub struct Distributor<DB: Database, G: GmpApiTrait + ThreadSafe> {
@@ -144,6 +145,18 @@ where
             if let Some(task_ids_filter) = &task_ids_filter {
                 if !task_ids_filter.contains(&task_id) {
                     continue;
+                }
+            }
+
+            if let Some(ref recovery) = self.recovery_settings {
+                if let Some(ref message_ids_filter) = recovery.message_ids_filter {
+                    let task_message_ids = extract_message_ids_from_task(&task);
+                    if !task_message_ids
+                        .iter()
+                        .any(|id| message_ids_filter.contains(id))
+                    {
+                        continue;
+                    }
                 }
             }
 

--- a/src/distributor.rs
+++ b/src/distributor.rs
@@ -151,9 +151,10 @@ where
             if let Some(ref recovery) = self.recovery_settings {
                 if let Some(ref message_ids_filter) = recovery.message_ids_filter {
                     let task_message_ids = extract_message_ids_from_task(&task);
-                    if !task_message_ids
-                        .iter()
-                        .any(|id| message_ids_filter.contains(id))
+                    if !task_message_ids.is_empty()
+                        && !task_message_ids
+                            .iter()
+                            .any(|id| message_ids_filter.contains(id))
                     {
                         continue;
                     }

--- a/src/distributor.rs
+++ b/src/distributor.rs
@@ -133,7 +133,7 @@ where
             self.last_task_id = Some(task_id.clone());
 
             if let Err(err) = maybe_instrument(self.store_last_task_id(), span.clone()).await {
-                warn!("{:?}", err);
+                warn!(task_id = %task_id, "Failed to store last_task_id: {:?}", err);
             }
             if let Some(tasks_filter) = &tasks_filter {
                 if !tasks_filter.contains(&task.kind()) {

--- a/src/ingestor.rs
+++ b/src/ingestor.rs
@@ -181,21 +181,26 @@ pub async fn run_ingestor(
 
     tokio::pin!(handle);
 
-    tokio::select! {
+    let handle_completed = tokio::select! {
         _ = sigint.recv()  => {
             sigint_cloned_token.cancel();
+            false
         },
         _ = sigterm.recv() => {
             sigterm_cloned_token.cancel();
+            false
         },
         _ = &mut handle => {
             info!("Ingestor stopped");
             ingestor_cloned_token.cancel();
+            true
         }
-    }
+    };
 
     tasks_queue.close().await;
     events_queue.close().await;
-    let _ = handle.await;
+    if !handle_completed {
+        let _ = handle.await;
+    }
     Ok(())
 }

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -88,7 +88,11 @@ where
                         debug!("Published tx: {:?}", item);
                     } else {
                         error!(
-                            account_id = self.transaction_poller.account_id(&account).as_deref().unwrap_or("unknown"),
+                            account_id = self
+                                .transaction_poller
+                                .account_id(&account)
+                                .as_deref()
+                                .unwrap_or("unknown"),
                             "Error making queue item: {:?}", maybe_chain_transaction
                         );
                     }
@@ -96,7 +100,11 @@ where
             }
             Err(e) => {
                 error!(
-                    account_id = self.transaction_poller.account_id(&account).as_deref().unwrap_or("unknown"),
+                    account_id = self
+                        .transaction_poller
+                        .account_id(&account)
+                        .as_deref()
+                        .unwrap_or("unknown"),
                     "Error getting txs: {:?}", e
                 );
                 debug!("Retrying in 2 seconds");

--- a/src/subscriber.rs
+++ b/src/subscriber.rs
@@ -87,12 +87,18 @@ where
                         maybe_instrument(queue.publish(item.clone()), span).await;
                         debug!("Published tx: {:?}", item);
                     } else {
-                        error!("Error making queue item: {:?}", maybe_chain_transaction);
+                        error!(
+                            account_id = self.transaction_poller.account_id(&account).as_deref().unwrap_or("unknown"),
+                            "Error making queue item: {:?}", maybe_chain_transaction
+                        );
                     }
                 }
             }
             Err(e) => {
-                error!("Error getting txs: {:?}", e);
+                error!(
+                    account_id = self.transaction_poller.account_id(&account).as_deref().unwrap_or("unknown"),
+                    "Error getting txs: {:?}", e
+                );
                 debug!("Retrying in 2 seconds");
             }
         }
@@ -113,6 +119,7 @@ where
         let span = info_span!("recover_txs");
 
         for tx in txs {
+            let tx_id = tx.clone();
             let res = maybe_instrument(self.transaction_poller.poll_tx(tx), span.clone()).await;
 
             match res {
@@ -125,11 +132,11 @@ where
                         queue.publish(item.clone()).await;
                         debug!("Published tx: {:?}", item);
                     } else {
-                        error!("Error making queue item: {:?}", maybe_chain_transaction);
+                        error!(tx_id = %tx_id, "Error making queue item: {:?}", maybe_chain_transaction);
                     }
                 }
                 Err(e) => {
-                    error!("Error getting txs: {:?}", e);
+                    error!(tx_id = %tx_id, "Error getting txs: {:?}", e);
                     debug!("Retrying in 2 seconds");
                 }
             }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because it changes runtime/deployment wiring (Docker Compose names, added service) and adds new recovery filtering logic that could inadvertently skip tasks if misconfigured.
> 
> **Overview**
> **Docker/ops changes:** Docker Compose now prefixes the project and network names with `NETWORK`, and adds a new `heartbeat_monitor` service; the Docker build cache stubs and `Cargo.toml` binaries list were updated accordingly. `.gitignore` also adds `config.stagenet.yaml`.
> 
> **Runtime logic tweaks:** Recovery mode can now optionally filter tasks by message ID via `RecoverySettings.message_ids_filter`, and error logs in `Distributor`/`Subscriber` include `task_id`/`account_id`/`tx_id` for better diagnostics. `run_ingestor` now tracks whether the spawned ingestor task completed to avoid an unnecessary double-await during shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3b2ebe2821c2ad06341eea5499389440b179714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->