### PR TITLE
fix(queue_consumer): get new consumer on None or Error instead of restarting binary

### DIFF
--- a/src/includer.rs
+++ b/src/includer.rs
@@ -4,7 +4,7 @@ use lapin::options::BasicAckOptions;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info, info_span, warn};
+use tracing::{debug, error, info, info_span};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::gmp_api::utils::extract_message_ids_from_task;
@@ -135,23 +135,15 @@ where
     }
 
     pub async fn run(&self, queue: Arc<dyn QueueTrait>, token: CancellationToken) {
-        loop {
-            match queue.consumer().await {
-                Ok(mut consumer) => {
-                    info!("Includer is alive.");
-                    self.work(&mut consumer, Arc::clone(&queue), token.clone())
-                        .await;
-                    if token.is_cancelled() {
-                        break;
-                    }
-                    warn!("Consumer stream ended unexpectedly. Recreating in 5s...");
-                }
-                Err(e) => {
-                    error!("Failed to create consumer: {:?}. Retrying in 5s...", e);
-                }
+        let mut consumer = match queue.consumer().await {
+            Ok(consumer) => consumer,
+            Err(e) => {
+                error!("Failed to create consumer: {:?}", e);
+                return;
             }
-            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-        }
+        };
+        info!("Includer is alive.");
+        self.work(&mut consumer, Arc::clone(&queue), token).await;
         info!("Includer is done.");
     }
 }

--- a/src/includer.rs
+++ b/src/includer.rs
@@ -4,7 +4,7 @@ use lapin::options::BasicAckOptions;
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
-use tracing::{debug, error, info, info_span};
+use tracing::{debug, error, info, info_span, warn};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::gmp_api::utils::extract_message_ids_from_task;
@@ -144,6 +144,6 @@ where
         };
         info!("Includer is alive.");
         self.work(&mut consumer, Arc::clone(&queue), token).await;
-        info!("Includer is done.");
+        warn!("Queue consumer closed.");
     }
 }

--- a/src/queue_consumer.rs
+++ b/src/queue_consumer.rs
@@ -4,10 +4,13 @@ use async_trait::async_trait;
 use lapin::message::Delivery;
 use lapin::Consumer;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::select;
 use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
+
+const CONSUMER_RECREATE_DELAYS_SECS: [u64; 3] = [1, 3, 5];
 
 #[async_trait]
 pub trait QueueConsumer {
@@ -26,7 +29,7 @@ pub trait QueueConsumer {
     ) {
         let tracker = TaskTracker::new();
 
-        loop {
+        'outer: loop {
             debug!("Task tracker size: {}", tracker.len());
             debug!("Waiting for messages from {}", consumer.queue());
             select! {
@@ -40,11 +43,16 @@ pub trait QueueConsumer {
                             self.on_delivery(delivery, Arc::clone(&queue), &tracker).await;
                         }
                         Some(Err(e)) => {
-                            error!("Failed to receive delivery: {:?}", e);
+                            error!("Failed to receive delivery: {:?}. Attempting to recreate consumer.", e);
+                            if !recreate_consumer(consumer, &queue, &token).await {
+                                break 'outer;
+                            }
                         }
                         None => {
-                            warn!("Consumer stream ended, returning to caller");
-                            break;
+                            warn!("Consumer stream ended. Attempting to recreate consumer.");
+                            if !recreate_consumer(consumer, &queue, &token).await {
+                                break 'outer;
+                            }
                         }
                     }
                 }
@@ -55,4 +63,50 @@ pub trait QueueConsumer {
         tracker.close();
         tracker.wait().await;
     }
+}
+
+/// Attempts to recreate the consumer with bounded backoff. Returns `true` if a
+/// new consumer was installed in `*consumer`, `false` if every attempt failed
+/// or the token was cancelled mid-retry (in which case the caller should exit
+/// the work loop).
+async fn recreate_consumer(
+    consumer: &mut Consumer,
+    queue: &Arc<dyn QueueTrait>,
+    token: &CancellationToken,
+) -> bool {
+    for (idx, delay_secs) in CONSUMER_RECREATE_DELAYS_SECS.iter().enumerate() {
+        let attempt = idx + 1;
+        let max = CONSUMER_RECREATE_DELAYS_SECS.len();
+
+        select! {
+            _ = token.cancelled() => {
+                info!("Cancellation during consumer recreation; aborting retries.");
+                return false;
+            }
+            _ = tokio::time::sleep(Duration::from_secs(*delay_secs)) => {}
+        }
+
+        match queue.consumer().await {
+            Ok(new_consumer) => {
+                info!(
+                    "Consumer recreated successfully on attempt {}/{}",
+                    attempt, max
+                );
+                *consumer = new_consumer;
+                return true;
+            }
+            Err(e) => {
+                warn!(
+                    "Consumer recreation attempt {}/{} failed: {:?}",
+                    attempt, max, e
+                );
+            }
+        }
+    }
+
+    error!(
+        "Failed to recreate consumer after {} attempts; exiting work loop",
+        CONSUMER_RECREATE_DELAYS_SECS.len()
+    );
+    false
 }

--- a/src/queue_consumer.rs
+++ b/src/queue_consumer.rs
@@ -10,7 +10,7 @@ use tokio_util::sync::CancellationToken;
 use tokio_util::task::TaskTracker;
 use tracing::{debug, error, info, warn};
 
-const CONSUMER_RECREATE_DELAYS_SECS: [u64; 3] = [1, 3, 5];
+const CONSUMER_RECREATE_DELAYS_SECS: [u64; 3] = [5, 10, 15];
 
 #[async_trait]
 pub trait QueueConsumer {
@@ -43,7 +43,7 @@ pub trait QueueConsumer {
                             self.on_delivery(delivery, Arc::clone(&queue), &tracker).await;
                         }
                         Some(Err(e)) => {
-                            error!("Failed to receive delivery: {:?}. Attempting to recreate consumer.", e);
+                            warn!("Failed to receive delivery: {:?}. Attempting to recreate consumer.", e);
                             if !recreate_consumer(consumer, &queue, &token).await {
                                 break 'outer;
                             }
@@ -113,7 +113,7 @@ async fn recreate_consumer(
     }
 
     error!(
-        "Failed to recreate consumer after {} attempts; exiting work loop",
+        "Failed to recreate consumer after {} attempts",
         CONSUMER_RECREATE_DELAYS_SECS.len()
     );
     false

--- a/src/queue_consumer.rs
+++ b/src/queue_consumer.rs
@@ -86,7 +86,15 @@ async fn recreate_consumer(
             _ = tokio::time::sleep(Duration::from_secs(*delay_secs)) => {}
         }
 
-        match queue.consumer().await {
+        let consumer_result = select! {
+            _ = token.cancelled() => {
+                info!("Cancellation during consumer recreation; aborting retries.");
+                return false;
+            }
+            res = queue.consumer() => res,
+        };
+
+        match consumer_result {
             Ok(new_consumer) => {
                 info!(
                     "Consumer recreated successfully on attempt {}/{}",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core message-ingestion reliability for includer/ingestor; failures after three recreate attempts now stop processing until an external restart, which is safer than an infinite outer loop but shifts operational behavior.
> 
> **Overview**
> Moves **RabbitMQ consumer recovery** from the includer's outer restart loop into the shared `QueueConsumer::work` path so transient stream failures are handled **in-process** instead of relying on the binary to loop forever.
> 
> When `consumer.next()` returns an **error** or **end-of-stream** (`None`), `work` now calls `recreate_consumer`, which retries `queue.consumer()` up to **three times** with **5s / 10s / 15s** delays, respects **cancellation** during waits and connect, and either swaps in a new `Consumer` and continues the message loop or exits after all attempts fail. **Includer::run** is simplified to create the consumer once, run `work` once, and log when the consumer closes; initial consumer creation failure still **returns early** with no retry at that layer.
> 
> **Ingestor** (and any other `QueueConsumer` implementor) picks up the same in-loop recreation behavior without duplicating retry logic in each service's `run` method.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83b87d2b1cf5dff52a2ae6daa3c98908084c9e91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->